### PR TITLE
Handle escaped newline sequences in Sol-37 terminal output

### DIFF
--- a/sol37/index.html
+++ b/sol37/index.html
@@ -469,7 +469,16 @@
   const winTerminal = $('#win-terminal');
   let history = []; let hIndex = -1;
 
-  function print(txt){ out.innerHTML += txt + "\\n"; out.scrollTop = out.scrollHeight; }
+  function print(txt){
+    const normalized = String(txt)
+      .replace(/\r\n/g, '\n')
+      .replace(/\r/g, '\n')
+      .replace(/\\r\\n/g, '\n')
+      .replace(/\\r/g, '\n')
+      .replace(/\\n/g, '\n');
+    out.appendChild(document.createTextNode(normalized + "\n"));
+    out.scrollTop = out.scrollHeight;
+  }
   function banner(){
     print("Sol‑37 Interactive Shell (retro)\\nType 'help' to begin.\\n");
   }
@@ -531,7 +540,7 @@
       try { window.open(arg, '_blank'); print("Opening: " + arg); } catch(e){ print("Could not open URL."); }
     },
     echo(arg){ print(arg||''); },
-    clear(){ out.innerHTML = ''; },
+    clear(){ out.textContent = ''; },
     theme(arg){
       const b = document.body;
       b.classList.remove('theme-amber','theme-gray');


### PR DESCRIPTION
## Summary
- normalize terminal output text to convert escaped CR/LF sequences into real newlines
- ensure Sol-37 command prompt renders banner and command output with proper line breaks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690bf1a98aa48324ab53a3e8d3ae6d2c