### PR TITLE
Generalize screenplay log to remove weekday-specific labels

### DIFF
--- a/house.html
+++ b/house.html
@@ -399,7 +399,7 @@
     <section style="margin-top:14px;">
       <div class="sec-h">
         <h2>Screenplay Log</h2>
-        <div class="tag mono">Fri → Sun execution</div>
+        <div class="tag mono">Multi-day execution</div>
       </div>
       <div class="sec-b">
         <p class="muted">
@@ -409,7 +409,7 @@
         <div class="timeline">
           <div class="beat">
             <div class="t">
-              <h3>EXT. WEATHERFORD SKY — FRIDAY MORNING <span class="pill a">OPEN</span></h3>
+              <h3>EXT. WEATHERFORD SKY — MORNING <span class="pill a">OPEN</span></h3>
               <div class="time">08:30</div>
             </div>
             <p>
@@ -425,7 +425,7 @@
 
           <div class="beat">
             <div class="t">
-              <h3>INT. MAIN KITCHEN — FRIDAY MIDDAY <span class="pill g">PIPELINE</span></h3>
+              <h3>INT. MAIN KITCHEN — MIDDAY <span class="pill g">PIPELINE</span></h3>
               <div class="time">11:30</div>
             </div>
             <p>Dishwasher becomes the engine. Clear one counter to become the clean staging surface.</p>
@@ -437,7 +437,7 @@
 
           <div class="beat">
             <div class="t">
-              <h3>INT. MESS HALL KITCHENETTE — FRIDAY AFTERNOON <span class="pill w">SCOPE</span></h3>
+              <h3>INT. MESS HALL KITCHENETTE — AFTERNOON <span class="pill w">SCOPE</span></h3>
               <div class="time">14:00</div>
             </div>
             <p>
@@ -452,7 +452,7 @@
 
           <div class="beat">
             <div class="t">
-              <h3>INT. BOTH KITCHENS — FRIDAY CLOSE <span class="pill a">CLOSE</span></h3>
+              <h3>INT. BOTH KITCHENS — CLOSE <span class="pill a">CLOSE</span></h3>
               <div class="time">18:00</div>
             </div>
             <p>Easy dishes washed. Heavy items soak overnight. Dishwasher runs if half-full.</p>
@@ -464,7 +464,7 @@
 
           <div class="beat">
             <div class="t">
-              <h3>INT. BOTH KITCHENS — SATURDAY DISH MARATHON <span class="pill g">RESTORE</span></h3>
+              <h3>INT. BOTH KITCHENS — DISH MARATHON <span class="pill g">RESTORE</span></h3>
               <div class="time">09:00–15:00</div>
             </div>
             <p>
@@ -480,7 +480,7 @@
 
           <div class="beat">
             <div class="t">
-              <h3>INT. BOTH KITCHENS — SUNDAY FLOORS <span class="pill a">BASE LAYER</span></h3>
+              <h3>INT. BOTH KITCHENS — FLOORS <span class="pill a">BASE LAYER</span></h3>
               <div class="time">09:30–12:30</div>
             </div>
             <p>


### PR DESCRIPTION
### Motivation
- Make the screenplay/runbook schedule flexible so it can be used starting on any day rather than being tied to Fri/Sat/Sun.
- Avoid implying a fixed weekend schedule when operations may begin on a different day such as Saturday.
- Preserve the existing structure and timing cues while removing explicit weekday references.

### Description
- Updated `house.html` to change the screenplay log tag from `Fri → Sun execution` to `Multi-day execution`.
- Removed weekday qualifiers from beat headings (for example, `FRIDAY MORNING` → `MORNING`, `FRIDAY MIDDAY` → `MIDDAY`, `FRIDAY AFTERNOON` → `AFTERNOON`, `FRIDAY CLOSE` → `CLOSE`, `SATURDAY DISH MARATHON` → `DISH MARATHON`, `SUNDAY FLOORS` → `FLOORS`).
- Kept all existing time cues and content intact so behavior and visual layout remain the same.
- Only the static HTML text was changed in the `house.html` timeline section.

### Testing
- No automated tests were run because this is a static HTML text change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696125a294b883249dba5e7f80d75a54)