### PR TITLE
Improve thesis equation wrapping

### DIFF
--- a/thesis.html
+++ b/thesis.html
@@ -233,7 +233,8 @@
       padding:12px 12px;
       overflow:auto;
       margin:10px 0;
-      white-space:pre;
+      white-space:pre-wrap;
+      overflow-wrap:anywhere;
     }
     .small{font-size:13px; color:var(--muted)}
     .footnotes{


### PR DESCRIPTION
### Motivation
- Prevent long lines in the `.equation` callout from overflowing their container and breaking layout on small viewports.

### Description
- Change `.equation` CSS in `thesis.html` to use `white-space: pre-wrap` and add `overflow-wrap: anywhere` so equations wrap and may break as needed.

### Testing
- Served the page with `python -m http.server 8000` and captured a full-page screenshot with a Playwright script to verify wrapping (screenshot saved as `artifacts/thesis-wrapping.png`), and the check ran successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698957e6f6c88324bb2934906c5e7c47)