### PR TITLE
Improve thesis layout and equation wrapping on small screens

### DIFF
--- a/thesis.html
+++ b/thesis.html
@@ -144,6 +144,12 @@
       .controls{align-items:stretch; min-width:auto}
       .note{text-align:left; max-width:none}
     }
+    @media (max-width: 640px){
+      header{flex-direction:column}
+      .grid{display:block}
+      nav.toc{position:static; margin-bottom:16px}
+      .toc a{padding:6px 8px}
+    }
 
     nav.toc{
       border:1px solid var(--line);
@@ -233,7 +239,8 @@
       padding:12px 12px;
       overflow:auto;
       margin:10px 0;
-      white-space:pre;
+      white-space:pre-wrap;
+      overflow-wrap:anywhere;
     }
     .small{font-size:13px; color:var(--muted)}
     .footnotes{


### PR DESCRIPTION
### Motivation
- Prevent layout breakage on narrow viewports by stacking header and disabling sticky table-of-contents behavior at mobile widths.
- Ensure long equations do not overflow their container and can wrap or break as needed on small screens.

### Description
- Add `@media (max-width: 640px)` rules in `thesis.html` to stack the header, make `.grid` use `display:block`, set `nav.toc` to `position:static` with `margin-bottom:16px`, and reduce `.toc a` padding to `6px 8px`.
- Update the `.equation` rule to use `white-space: pre-wrap` and `overflow-wrap: anywhere` so equations wrap and may break within their container.
- Tighten small-screen spacing and layout to improve readability on phones and small tablets.

### Testing
- Launched a static server with `python -m http.server 8000` and ran a Playwright script that loaded `/thesis.html` at a `480x900` viewport and saved `artifacts/thesis-mobile.png`, and the script completed successfully.
- The visual verification screenshot was produced and shows the intended mobile layout and wrapping behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698957e6f6c88324bb2934906c5e7c47)