### PR TITLE
Widen thesis layout breakpoint and improve equation wrapping on small windows

### DIFF
--- a/thesis.html
+++ b/thesis.html
@@ -139,10 +139,16 @@
       gap:16px;
       margin-top:16px;
     }
-    @media (max-width: 920px){
+    @media (max-width: 1100px){
       .grid{grid-template-columns:1fr}
       .controls{align-items:stretch; min-width:auto}
       .note{text-align:left; max-width:none}
+      nav.toc{position:static; margin-bottom:16px}
+    }
+    @media (max-width: 640px){
+      header{flex-direction:column}
+      .grid{display:block}
+      .toc a{padding:6px 8px}
     }
 
     nav.toc{
@@ -233,7 +239,8 @@
       padding:12px 12px;
       overflow:auto;
       margin:10px 0;
-      white-space:pre;
+      white-space:pre-wrap;
+      overflow-wrap:anywhere;
     }
     .small{font-size:13px; color:var(--muted)}
     .footnotes{


### PR DESCRIPTION
### Motivation
- Prevent layout breakage and TOC overlap in narrow site GUI windows by switching to a single-column layout earlier.
- Allow long equations to wrap or break instead of overflowing their container on small viewports.

### Description
- Change the grid breakpoint from `@media (max-width: 920px)` to `@media (max-width: 1100px)` so the layout collapses to a single column sooner.
- Disable sticky TOC earlier by adding `nav.toc { position: static; margin-bottom: 16px }` inside the `1100px` breakpoint to avoid overlap in narrow windows.
- Keep mobile-specific rules in `@media (max-width: 640px)` including `header` stacking, `.grid` switching to `display:block`, and reduced `.toc a` padding.
- Update `.equation` styling to `white-space: pre-wrap` and `overflow-wrap: anywhere` so long equations wrap and may break within their container.

### Testing
- Launched a static server with `python -m http.server 8000` and ran a Playwright script that loaded `/thesis.html` at viewport `900x700` and saved `artifacts/thesis-small-window.png`, and the script completed successfully.
- No automated unit tests were added since this is a static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698957e6f6c88324bb2934906c5e7c47)