### PR TITLE
Improve thesis responsiveness for small windows

### DIFF
--- a/posts/thesis.html
+++ b/posts/thesis.html
@@ -48,10 +48,11 @@
                   var(--bg);
       color:var(--text);
       line-height:1.55;
+      overflow-x:hidden;
     }
     a{color:var(--accent); text-decoration:none}
     a:hover{text-decoration:underline}
-    .wrap{max-width:1080px; margin:0 auto; padding:28px 18px 80px}
+    .wrap{max-width:1080px; margin:0 auto; padding:24px 18px 72px}
     header{
       display:flex; gap:18px; align-items:flex-start; justify-content:space-between;
       padding:22px 22px; border:1px solid var(--line);
@@ -135,7 +136,7 @@
 
     .grid{
       display:grid;
-      grid-template-columns: 320px 1fr;
+      grid-template-columns: minmax(220px, 32%) 1fr;
       gap:16px;
       margin-top:16px;
     }
@@ -144,11 +145,29 @@
       .controls{align-items:stretch; min-width:auto}
       .note{text-align:left; max-width:none}
     }
+    @media (max-width: 860px){
+      header{flex-direction:column; align-items:stretch}
+      .controls{flex-direction:row; flex-wrap:wrap; align-items:stretch}
+      .controls button{flex:1 1 160px}
+      .note{text-align:left}
+    }
     @media (max-width: 640px){
-      header{flex-direction:column}
+      .wrap{padding:18px 12px 48px}
+      header{flex-direction:column; padding:16px}
+      .titleblock{max-width:100%}
       .grid{display:block}
       nav.toc{position:static; margin-bottom:16px}
       .toc a{padding:6px 8px}
+      .controls{flex-direction:column}
+      button{font-size:11px; padding:8px 10px}
+      main{padding:14px}
+      section{padding:12px 6px}
+    }
+    @media (max-height: 700px){
+      .wrap{padding-top:16px}
+      header{padding:16px}
+      .grid{gap:12px}
+      nav.toc{max-height:45vh; overflow:auto}
     }
 
     nav.toc{


### PR DESCRIPTION
### Motivation
- Make `posts/thesis.html` render nicely when opened inside the index.html GUI window and on smaller/mobile viewports. 
- Prevent horizontal overflow and cramped controls when the thesis is viewed in narrow or short windows.

### Description
- Added `overflow-x:hidden` on `body` and reduced outer `wrap` padding to reduce page-wide overflow and spacing on small viewports. 
- Replaced fixed two-column layout with `grid-template-columns: minmax(220px, 32%) 1fr` to allow the TOC column to shrink gracefully. 
- Added responsive rules: a new `@media (max-width:860px)` to rearrange header controls into rows and `@media (max-width:640px)` to further compress padding, button sizing, and section spacing for mobile. 
- Added `@media (max-height:700px)` to limit `nav.toc` height with `max-height:45vh; overflow:auto` and reduce gaps/padding for short viewports.

### Testing
- Performed a visual smoke test by serving the site with `python -m http.server 8000` and running a Playwright script to load `http://127.0.0.1:8000/index.html` at `900x600` and capture a screenshot, which completed successfully. 
- No unit tests exist for this static HTML/CSS change, and the change was committed after verification in the local dev server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698964eca7bc832488069d12d725d70b)