### PR TITLE
Harden archive counter fetch and soften failure display

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,15 @@
   .task-button.active { outline: 2px solid #000080; color: #000; background: #dfdfdf; }
 
   .tray { justify-self: end; display: flex; justify-content: flex-end; gap: 6px; align-items: center; }
+  #archive-counter {
+    font-family: monospace;
+    font-size: 11px;
+    color: #555;
+    opacity: 0.8;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
+  }
+  #archive-counter span { color: #777; }
   .clock { background: #dfdfdf; border: 1px solid #000; box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080; padding: 2px 6px; font-size: 12px; min-width: 110px; text-align: center; }
 
   /* --------- Icons / Desktop --------- */
@@ -262,6 +271,9 @@
     </button>
     <div class="task-buttons" id="task-buttons"></div>
     <div class="tray">
+      <div id="archive-counter" title="Aggregate access events. No personal data stored.">
+        Archive access count: <span id="counter">—</span>
+      </div>
       <div class="clock" id="clock">--:-- --</div>
     </div>
   </footer>
@@ -474,6 +486,23 @@
 
   // Clock
   const clock = $('#clock');
+  const counter = $('#counter');
+
+  fetch('https://api.countapi.xyz/update/davidlones.github.io/index?amount=1')
+    .then(res => res.json())
+    .then(data => {
+      if (!counter) return;
+      if (typeof data.value === 'number') {
+        counter.textContent = data.value.toLocaleString();
+      } else {
+        counter.textContent = '—';
+      }
+    })
+    .catch(err => {
+      console.warn('Archive counter unavailable:', err);
+      if (counter) counter.textContent = '—';
+    });
+
   function updateClock(){
     const d = new Date();
     const hrs = d.getHours();


### PR DESCRIPTION
### Motivation
- The CountAPI `/hit/` request was failing at runtime on GitHub Pages for some users due to blockers/CORS/namespace issues, causing the UI to show a loud "unavailable" message. 
- Make the increment/request path more reliable and make the failure state less noisy while keeping the same increment semantics.

### Description
- Replaced the `/hit/` call with an explicit `https://api.countapi.xyz/update/davidlones.github.io/index?amount=1` request to make the increment path explicit and avoid `/hit/` edge cases. 
- Added a dedicated archive counter element in the taskbar markup (`#archive-counter` with a child `#counter`) and small monospace styling for consistent presentation. 
- Improved JS robustness by guarding the missing DOM node, treating non-numeric responses as an em dash (`—`), and logging a diagnostic `console.warn` on network or parse failure instead of showing `unavailable` to users.

### Testing
- Reviewed the modified `index.html` to confirm the change is limited to the counter markup, styles, and fetch block and that no unrelated code was altered. 
- Attempted to query the updated CountAPI endpoint with `curl` to validate the JSON response, but the environment outbound proxy returned `502 Bad Gateway`, so live endpoint verification failed in this environment. 
- Performed a local commit of the change and verified the diff to ensure only the intended block was updated (no automated runtime tests executed due to the network/proxy limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e975781a88324a1e524b89272ce8b)