### PR TITLE
Add Tinylytics archive hit counter to taskbar tray

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,13 @@
   .task-button.active { outline: 2px solid #000080; color: #000; background: #dfdfdf; }
 
   .tray { justify-self: end; display: flex; justify-content: flex-end; gap: 6px; align-items: center; }
+  #archive-counter {
+    font-family: monospace;
+    font-size: 11px;
+    color: #555;
+    opacity: 0.85;
+    white-space: nowrap;
+  }
   .clock { background: #dfdfdf; border: 1px solid #000; box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080; padding: 2px 6px; font-size: 12px; min-width: 110px; text-align: center; }
 
   /* --------- Icons / Desktop --------- */
@@ -262,6 +269,9 @@
     </button>
     <div class="task-buttons" id="task-buttons"></div>
     <div class="tray">
+      <div id="archive-counter" title="Aggregate access count. No personal data stored.">
+        Archive access: <span class="tinylytics_hits">—</span>
+      </div>
       <div class="clock" id="clock">--:-- --</div>
     </div>
   </footer>
@@ -854,5 +864,6 @@
 
 })();
 </script>
+<script defer src="https://tinylytics.app/embed/BLs8Pz1x77uyP9Ps6uFS.js?hits"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Add a passive, non-invasive archive hit counter to the taskbar tray so visitors can see aggregate access counts (with a safe em-dash fallback and no personal data collection). 

### Description
- Inserted an `#archive-counter` element inside the `.tray` in `index.html` containing `Archive access: <span class="tinylytics_hits">—</span>`, added small optional styling for `#archive-counter`, and added the Tinylytics embed script (`<script defer src="https://tinylytics.app/embed/BLs8Pz1x77uyP9Ps6uFS.js?hits"></script>`) just before `</body>` so it passively hydrates `.tinylytics_hits`.

### Testing
- Ran `git diff --check` which returned no formatting/whitespace issues, and attempted a Playwright render+Screenshot but the browser process crashed with `SIGSEGV` so automated visual capture could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ea80fc4e0832484a9e8dcc6ea0c12)