### PR TITLE
Fix mobile icon label overlap by enforcing icon bounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,8 +99,24 @@
 
   /* --------- Icons / Desktop --------- */
   .desktop { position: absolute; inset: 0 0 32px 0; }
-  .desktop a.icon { position: absolute; width: 88px; text-align: center; color: #fff; text-decoration: none; font-size: 12px; }
+  .desktop a.icon {
+    position: absolute;
+    width: 96px;
+    text-align: center;
+    color: #fff;
+    text-decoration: none;
+    font-size: 12px;
+  }
   .desktop a.icon img { width: 48px; height: 48px; display: block; margin: 0 auto 4px; image-rendering: pixelated; }
+  .desktop a.icon span {
+    display: block;
+    margin-top: 6px;
+    line-height: 14px;
+    max-width: 100%;
+    min-height: 28px;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+  }
 
   /* --------- Command Prompt --------- */
   .terminal {
@@ -143,7 +159,7 @@
 
   @media (max-width: 640px) {
     .win95-window { min-width: auto; min-height: 160px; }
-    .desktop a.icon { width: 80px; }
+    .desktop a.icon { width: 96px; }
     #archive-counter { max-width: 0; overflow: hidden; opacity: 0; pointer-events: none; }
   }
 


### PR DESCRIPTION
### Motivation
- Mobile icon labels were bleeding into adjacent grid cells because icons were absolutely positioned while labels flowed unconstrained.  
- The layout lacked an enforced per-icon bounding box, allowing text to expand beyond the intended column when the viewport compresses.  
- A CSS-only, non-hacky fix is needed to keep the retro desktop feel while preventing visual collisions on narrow viewports.

### Description
- Set `.desktop a.icon` to a fixed `width: 96px` and preserved `position: absolute` to enforce a per-icon bounding box.  
- Added `.desktop a.icon span` rules with `display: block`, `line-height: 14px`, `min-height: 28px`, and `overflow-wrap`/`word-wrap` to constrain wrapping and keep rows aligned.  
- Removed the previous narrower mobile override by making the media-query icon width match the desktop width so labels do not overflow under small viewports.

### Testing
- Reviewed the CSS diff in `index.html` to verify the new rules are present and target `.desktop a.icon` and its `span`.  
- Launched a local static server via `python3 -m http.server` to exercise the page in a browser environment.  
- Attempted an automated mobile screenshot using Playwright to confirm the rendering, but the headless Chromium runtime crashed with a SIGSEGV in this environment (Playwright capture failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ee62508788324860be5170a0280d1)