### PR TITLE
Reposition Star Map icon to prevent mobile label overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
       <img alt="Blog" src="data:image/svg+xml;utf8,<?xml version='1.0'?><svg xmlns='http://www.w3.org/2000/svg' width='48' height='48'><rect x='6' y='8' width='36' height='32' fill='%23fff' stroke='%23000'/><line x1='10' y1='14' x2='38' y2='14' stroke='%23000'/><line x1='10' y1='20' x2='38' y2='20' stroke='%23000'/><line x1='10' y1='26' x2='38' y2='26' stroke='%23000'/><line x1='10' y1='32' x2='28' y2='32' stroke='%23000'/></svg>">
       <span>Blog</span>
     </a>
-    <a class="icon" style="left:120px; top:184px;" href="#" data-program="star-map">
+    <a class="icon" style="left:16px; top:248px;" href="#" data-program="star-map">
       <img alt="Star Map" src="data:image/svg+xml;utf8,<?xml version='1.0'?><svg xmlns='http://www.w3.org/2000/svg' width='48' height='48'><rect width='48' height='48' fill='%23000020'/><circle cx='24' cy='24' r='12' fill='none' stroke='%23ffffff'/><circle cx='24' cy='24' r='2' fill='%23ffd700'/><circle cx='10' cy='11' r='1' fill='%23ffffff'/><circle cx='36' cy='15' r='1' fill='%23ffffff'/><circle cx='14' cy='33' r='1' fill='%23ffffff'/><circle cx='38' cy='35' r='1' fill='%23ffffff'/></svg>">
       <span>Star Map</span>
     </a>


### PR DESCRIPTION
### Motivation
- Prevent the Star Map icon label from colliding with the Blog label on narrow/mobile screens and ensure visual verification is taken from the desktop view.

### Description
- Update `index.html` to change the desktop anchor `a.icon[data-program="star-map"]` inline style from `left:120px; top:184px;` to `left:16px; top:248px;`, preserving the `<img>` immediately followed by `<span>` like the other icons.

### Testing
- Served the site with `python3 -m http.server 4173` and ran a Playwright script in a mobile viewport that closed open windows, asserted Blog and Star Map label bounding boxes do not overlap, opened and closed the Star Map window, and saved a desktop screenshot at `browser:/tmp/codex_browser_invocations/c2a954470e256b91/artifacts/artifacts/star-map-desktop-mobile.png`, with all assertions passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eeebe86c0832498e4f3d6005953a5)