### PR TITLE
Add Tinylytics event tracking for desktop, windows, terminal, and programs

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,19 +182,19 @@
 </head>
 <body>
   <div class="desktop" id="desktop">
-    <a class="icon" style="left:16px; top:16px;" href="#" data-open="about">
+    <a class="icon" style="left:16px; top:16px;" href="#" data-open="about" data-tinylytics-event="desktop.open" data-tinylytics-event-value="about">
       <img alt="My Computer" src="data:image/svg+xml;utf8,<?xml version='1.0'?><svg xmlns='http://www.w3.org/2000/svg' width='48' height='48'><rect width='48' height='36' y='6' fill='%23c0c0c0' stroke='%23000'/><rect x='4' y='10' width='40' height='24' fill='%23000080'/><rect x='12' y='36' width='24' height='6' fill='%237f7f7f' stroke='%23000'/></svg>">
       <span>Sol-37</span>
     </a>
-    <a class="icon" style="left:16px; top:100px;" href="#" data-open="terminal">
+    <a class="icon" style="left:16px; top:100px;" href="#" data-open="terminal" data-tinylytics-event="desktop.open" data-tinylytics-event-value="terminal">
       <img alt="Command" src="data:image/svg+xml;utf8,<?xml version='1.0'?><svg xmlns='http://www.w3.org/2000/svg' width='48' height='48'><rect width='48' height='36' y='6' fill='%23000' stroke='%2300ff00'/><text x='8' y='28' font-size='18' fill='%2300ff00' font-family='monospace'>&gt;_</text></svg>">
       <span>Command</span>
     </a>
-    <a class="icon" style="left:16px; top:184px;" href="#" data-open="blog">
+    <a class="icon" style="left:16px; top:184px;" href="#" data-open="blog" data-tinylytics-event="desktop.open" data-tinylytics-event-value="blog">
       <img alt="Blog" src="data:image/svg+xml;utf8,<?xml version='1.0'?><svg xmlns='http://www.w3.org/2000/svg' width='48' height='48'><rect x='6' y='8' width='36' height='32' fill='%23fff' stroke='%23000'/><line x1='10' y1='14' x2='38' y2='14' stroke='%23000'/><line x1='10' y1='20' x2='38' y2='20' stroke='%23000'/><line x1='10' y1='26' x2='38' y2='26' stroke='%23000'/><line x1='10' y1='32' x2='28' y2='32' stroke='%23000'/></svg>">
       <span>Blog</span>
     </a>
-    <a class="icon" style="left:16px; top:248px;" href="#" data-program="star-map">
+    <a class="icon" style="left:16px; top:248px;" href="#" data-program="star-map" data-tinylytics-event="desktop.open" data-tinylytics-event-value="star-map">
       <img alt="Star Map" src="data:image/svg+xml;utf8,<?xml version='1.0'?><svg xmlns='http://www.w3.org/2000/svg' width='48' height='48'><rect width='48' height='48' fill='%23000020'/><circle cx='24' cy='24' r='12' fill='none' stroke='%23ffffff'/><circle cx='24' cy='24' r='2' fill='%23ffd700'/><circle cx='10' cy='11' r='1' fill='%23ffffff'/><circle cx='36' cy='15' r='1' fill='%23ffffff'/><circle cx='14' cy='33' r='1' fill='%23ffffff'/><circle cx='38' cy='35' r='1' fill='%23ffffff'/></svg>">
       <span>Star Map</span>
     </a>
@@ -277,10 +277,10 @@
   <nav class="start-menu" id="start-menu" aria-hidden="true">
     <h4>Sol-37</h4>
     <ul>
-      <li data-open="terminal">Command Prompt</li>
-      <li data-open="blog">Blog</li>
-      <li data-program="star-map">Star Map</li>
-      <li data-open="about">About all this...</li>
+      <li data-open="terminal" data-tinylytics-event="menu.open" data-tinylytics-event-value="terminal">Command Prompt</li>
+      <li data-open="blog" data-tinylytics-event="menu.open" data-tinylytics-event-value="blog">Blog</li>
+      <li data-program="star-map" data-tinylytics-event="menu.launch" data-tinylytics-event-value="star-map">Star Map</li>
+      <li data-open="about" data-tinylytics-event="menu.open" data-tinylytics-event-value="about">About all this...</li>
       <li id="menu-theme">Themes ▸</li>
     </ul>
     <div class="submenu" id="menu-posts">
@@ -321,6 +321,18 @@
   const WIN_MARGIN_BOTTOM = 32;
   const MOBILE_QUERY = window.matchMedia('(max-width: 640px)');
   const isMobile = () => MOBILE_QUERY.matches;
+  
+  const trackTinylyticsEvent = (eventName, value) => {
+    const probe = document.createElement('button');
+    probe.type = 'button';
+    probe.style.display = 'none';
+    probe.setAttribute('aria-hidden', 'true');
+    probe.setAttribute('data-tinylytics-event', eventName);
+    if (value != null) probe.setAttribute('data-tinylytics-event-value', String(value));
+    document.body.appendChild(probe);
+    probe.click();
+    probe.remove();
+  };
 
   MOBILE_QUERY.addEventListener?.('change', () => {
     $$('.win95-window, [id^="doc-"]').forEach(clampToViewport);
@@ -423,6 +435,7 @@
     win.querySelectorAll('.titlebar [data-action]').forEach(btn => {
       btn.addEventListener('click', () => {
         const act = btn.dataset.action;
+        trackTinylyticsEvent('window.' + act, win.id.replace(/^win-|^doc-|^prog-/, ''));
         const taskBtn = ensureTaskButton(win);
 
         if (act === 'close') {
@@ -599,6 +612,8 @@
       const li = document.createElement('li');
       li.textContent = `${p.title}${p.date? ' — '+p.date:''}`;
       li.dataset.id = p.id;
+      li.setAttribute('data-tinylytics-event', 'post.open');
+      li.setAttribute('data-tinylytics-event-value', p.id);
       li.addEventListener('click', ()=> openPost(p.id));
       postsListEl.appendChild(li);
     });
@@ -616,6 +631,8 @@
       a.href = '#';
       a.dataset.doc = p.id;
       a.title = p.title;
+      a.setAttribute('data-tinylytics-event', 'post.open');
+      a.setAttribute('data-tinylytics-event-value', p.id);
 
       const svg = "data:image/svg+xml;utf8," + encodeURIComponent(`<?xml version='1.0'?>
         <svg xmlns='http://www.w3.org/2000/svg' width='48' height='48'>
@@ -648,6 +665,8 @@
         const div = document.createElement('div');
         div.className = 'item';
         div.textContent = p.title;
+        div.setAttribute('data-tinylytics-event', 'post.open');
+        div.setAttribute('data-tinylytics-event-value', p.id);
         div.addEventListener('click', () => {
           startMenu.style.display='none';
           openHtmlDocumentWindow(p);
@@ -662,6 +681,8 @@
         const div = document.createElement('div');
         div.className = 'item';
         div.textContent = p.title;
+        div.setAttribute('data-tinylytics-event', 'post.open');
+        div.setAttribute('data-tinylytics-event-value', p.id);
         div.addEventListener('click', async () => {
           startMenu.style.display='none';
           toggleWindow($('#win-blog'));
@@ -717,6 +738,7 @@
   }
 
   function openProgramWindow(prog){
+    trackTinylyticsEvent('program.launch', prog.id);
     let win = document.getElementById('prog-' + prog.id);
     if (!win) {
       win = document.createElement('section');
@@ -808,6 +830,7 @@
       print(`C:\\SOL37> ${raw}`);
       input.value = '';
       const [cmd, ...rest] = raw.split(/\s+/);
+      trackTinylyticsEvent('terminal.command', cmd.toLowerCase());
       const arg = rest.join(' ');
       commands[cmd.toLowerCase()]?.(arg) ?? print(`Unknown command: ${cmd}. Type 'help'.`);
     } else if (e.key === 'ArrowUp') {
@@ -864,6 +887,6 @@
   $('#win-terminal').addEventListener('click', () => input.focus());
 })();
 </script>
-<script defer src="https://tinylytics.app/embed/BLs8Pz1x77uyP9Ps6uFS.js?hits"></script>
+<script defer src="https://tinylytics.app/embed/BLs8Pz1x77uyP9Ps6uFS.js?hits&events&beacon"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Add low-friction behavioral analytics to the retro desktop UI by enabling Tinylytics event capture and emitting a small, semantic event vocabulary without invasive JS surgery.
- Capture high-signal interactions (desktop icons, Start menu, window lifecycle, terminal commands, post opens, program launches) to measure entry points and content consumption while preserving the existing UI model.

### Description
- Upgrade the Tinylytics embed to include `?hits&events&beacon` so events are captured reliably even when navigation/iframes open. 
- Add declarative `data-tinylytics-event` and `data-tinylytics-event-value` attributes to desktop icons and Start menu items for `desktop.open`, `menu.open`, and `menu.launch` events. 
- Introduce `trackTinylyticsEvent(eventName, value)` that emits events by creating a hidden element with Tinylytics attributes and programmatically clicking it, and wire it into window titlebar actions to emit `window.close`, `window.minimize`, and `window.maximize`. 
- Instrument post interactions, dynamic desktop HTML icons, Start submenu items, program launches (`program.launch`), and terminal submissions (`terminal.command`) to provide post IDs and command names as event values. 

### Testing
- Ran `rg -n "tinylytics|trackTinylyticsEvent|program.launch|terminal.command|post.open|menu.open|desktop.open" index.html` to verify the new markers are present, which returned the expected matches. 
- Ran `git status --short` to confirm the working tree reflects the change, which reported the modified `index.html` file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f0d981cd48324b8a0d50e6d517e1b)