### PR TITLE
Add remaining Tinylytics interaction tracking hooks for Sol-37 UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,7 +352,10 @@
       btn.className = 'task-button';
       btn.textContent = winEl.querySelector('.titlebar span').textContent;
       btn.dataset.window = winEl.id;
-      btn.addEventListener('click', () => toggleWindow(winEl, true));
+      btn.addEventListener('click', () => {
+        trackTinylyticsEvent('taskbar.activate', winEl.id.replace(/^win-|^doc-|^prog-/, ''));
+        toggleWindow(winEl, true);
+      });
       $('#task-buttons').appendChild(btn);
     }
     return btn;
@@ -409,6 +412,7 @@
     let dragging = false, offX = 0, offY = 0;
 
     handle.addEventListener('dblclick', () => {
+      trackTinylyticsEvent('window.maximize', win.id.replace(/^win-|^doc-|^prog-/, ''));
       win.classList.toggle('maximized');
       bringToFront(win);
       clampToViewport(win);
@@ -497,6 +501,7 @@
 
   startBtn.addEventListener('click', () => {
     const open = startMenu.style.display === 'block';
+    trackTinylyticsEvent('start.toggle', open ? 'close' : 'open');
     startMenu.style.display = open ? 'none' : 'block';
     startBtn.setAttribute('aria-expanded', String(!open));
   });
@@ -512,6 +517,19 @@
     if (e.key === 'Escape') {
       startMenu.style.display = 'none';
       startBtn.setAttribute('aria-expanded','false');
+    }
+  });
+
+  document.addEventListener('click', (e) => {
+    const link = e.target.closest('a[href]');
+    if (!link) return;
+    const href = link.getAttribute('href') || '';
+    if (!/^https?:\/\//i.test(href)) return;
+    try {
+      const host = new URL(link.href, window.location.href).hostname;
+      trackTinylyticsEvent('link.external', host || 'unknown');
+    } catch {
+      trackTinylyticsEvent('link.external', 'unknown');
     }
   });
 


### PR DESCRIPTION
## Summary
- Added missing Tinylytics events for key SPA interactions that were not yet tracked.
- Kept the existing event taxonomy and value conventions already in `index.html`.

## Changes
- Track taskbar button clicks as `taskbar.activate` with normalized window/program/doc id values.
- Track Start button open/close toggles as `start.toggle` with `open`/`close` values.
- Track titlebar double-click maximize action as `window.maximize`.
- Track external link clicks globally as `link.external` with hostname as event value.

## Why
Sol-37 is a single-page desktop experience; path analytics alone cannot describe behavior. These additions fill remaining gaps so interaction funnels are visible in Tinylytics event reporting.

## Validation
- Static inspection of `index.html` confirms event hooks are present:
  - `start.toggle`
  - `taskbar.activate`
  - `window.maximize` (dblclick)
  - `link.external`

No runtime tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f1bdccfe48324bb80d279ef6f3548)