### PR TITLE
Add semantic Tinylytics event hooks

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,16 +322,8 @@
   const MOBILE_QUERY = window.matchMedia('(max-width: 640px)');
   const isMobile = () => MOBILE_QUERY.matches;
   
-  const trackTinylyticsEvent = (eventName, value) => {
-    const probe = document.createElement('button');
-    probe.type = 'button';
-    probe.style.display = 'none';
-    probe.setAttribute('aria-hidden', 'true');
-    probe.setAttribute('data-tinylytics-event', eventName);
-    if (value != null) probe.setAttribute('data-tinylytics-event-value', String(value));
-    document.body.appendChild(probe);
-    probe.click();
-    probe.remove();
+  const trackTinylyticsEvent = (eventName, payload) => {
+    window.tl?.('event', eventName, payload || {});
   };
 
   MOBILE_QUERY.addEventListener?.('change', () => {
@@ -368,6 +360,7 @@
       btn.classList.add('active');
       focusFirst(winEl);
       clampToViewport(winEl);
+      trackTinylyticsEvent('window_open', { id: winEl.id });
       return;
     }
 
@@ -435,13 +428,14 @@
     win.querySelectorAll('.titlebar [data-action]').forEach(btn => {
       btn.addEventListener('click', () => {
         const act = btn.dataset.action;
-        trackTinylyticsEvent('window.' + act, win.id.replace(/^win-|^doc-|^prog-/, ''));
         const taskBtn = ensureTaskButton(win);
 
         if (act === 'close') {
+          trackTinylyticsEvent('window_close', { id: win.id });
           win.classList.add('hidden');
           taskBtn.remove();
         } else if (act === 'minimize') {
+          trackTinylyticsEvent('window_minimize', { id: win.id });
           win.classList.add('hidden');
           taskBtn.classList.remove('active');
         } else if (act === 'maximize') {
@@ -695,6 +689,7 @@
 
   async function openPost(id){
     const p = MD_POSTS.find(x=>x.id===id); if(!p) return;
+    trackTinylyticsEvent('post_opened', { id });
     $$('#posts-list li').forEach(li=> li.classList.toggle('active', li.dataset.id===id));
     postViewer.innerHTML = `<h2>${p.title}</h2><p><em>${p.date||''}</em></p><p>Loading…</p>`;
     try{
@@ -707,6 +702,7 @@
   }
 
   function openHtmlDocumentWindow(p){
+    trackTinylyticsEvent('doc_opened', { id: p.id });
     let win = document.getElementById('doc-'+p.id);
     if (!win){
       win = document.createElement('section');
@@ -830,7 +826,7 @@
       print(`C:\\SOL37> ${raw}`);
       input.value = '';
       const [cmd, ...rest] = raw.split(/\s+/);
-      trackTinylyticsEvent('terminal.command', cmd.toLowerCase());
+      trackTinylyticsEvent('command_entered', { cmd: cmd.toLowerCase() });
       const arg = rest.join(' ');
       commands[cmd.toLowerCase()]?.(arg) ?? print(`Unknown command: ${cmd}. Type 'help'.`);
     } else if (e.key === 'ArrowUp') {
@@ -888,5 +884,8 @@
 })();
 </script>
 <script defer src="https://tinylytics.app/embed/BLs8Pz1x77uyP9Ps6uFS.js?hits&events&beacon"></script>
+<script>
+  window.tl = window.tl || function(){ (window.tl.q = window.tl.q || []).push(arguments); };
+</script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace brittle synthetic DOM-probe event dispatch with direct Tinylytics calls so analytics can carry structured payloads. 
- Emit higher-signal, semantic events for window lifecycle, navigation, and terminal commands to improve telemetry quality.

### Description
- Replaced the old hidden-button probe approach with a helper `trackTinylyticsEvent` that calls `window.tl?.('event', ...)` and accepts a structured `payload` object. 
- Added semantic events at key interaction points: `window_open` in `toggleWindow(...)`, `window_close` and `window_minimize` in the titlebar action handler, `post_opened` in `openPost(id)`, and `doc_opened` in `openHtmlDocumentWindow(p)`. 
- Replaced the terminal event name and payload from `terminal.command` to `command_entered` and send only the normalized `cmd` as `{ cmd }`. 
- Injected a Tinylytics queue helper right after the embed script so events queue safely before the SDK becomes available, and preserved existing `program.launch` behavior.

### Testing
- Verified occurrences with `rg -n "trackTinylyticsEvent|window_open|window_minimize|window_close|command_entered|post_opened|doc_opened|window\.tl|tinylytics.app/embed" index.html` and the expected lines were present (success). 
- Launched a local static server with `python3 -m http.server 8000` and exercised the UI via a Playwright script that captured a screenshot (artifact produced successfully). 
- Committed the changes and created the PR metadata; all automated checks performed in this run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f1e1646a08324ba731d8d7ac7a44d)