### PR TITLE
Link taskbar analytics indicator to public Tinylytics dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,12 +89,15 @@
 
   .tray { justify-self: end; display: flex; justify-content: flex-end; gap: 6px; align-items: center; }
   #archive-counter {
+    display: inline-block;
     font-family: monospace;
     font-size: 11px;
     color: #555;
     opacity: 0.85;
     white-space: nowrap;
+    text-decoration: none;
   }
+  #archive-counter:hover { text-decoration: underline; }
   .clock { background: #dfdfdf; border: 1px solid #000; box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080; padding: 2px 6px; font-size: 12px; min-width: 110px; text-align: center; }
 
   /* --------- Icons / Desktop --------- */
@@ -297,9 +300,9 @@
     </button>
     <div class="task-buttons" id="task-buttons"></div>
     <div class="tray">
-      <div id="archive-counter" title="Aggregate access count. No personal data stored.">
+      <a id="archive-counter" href="https://tinylytics.app/public/Lq8Z2-ixvVLzYXCEvk9D" target="_blank" rel="noopener noreferrer" title="Open public analytics dashboard (no personal data stored).">
         Archive access: <span class="tinylytics_hits">—</span>
-      </div>
+      </a>
       <div class="clock" id="clock">--:-- --</div>
     </div>
   </footer>


### PR DESCRIPTION
### Motivation
- Make the taskbar analytics indicator clickable so users go directly to the public Tinylytics dashboard at `https://tinylytics.app/public/Lq8Z2-ixvVLzYXCEvk9D`.

### Description
- Convert the taskbar element `#archive-counter` from a non-interactive `<div>` to an `<a>` pointing at the Tinylytics URL, add `target="_blank" rel="noopener noreferrer"`, and preserve styling by adding `display: inline-block`, `text-decoration: none`, and a hover underline.

### Testing
- Served the site with `python3 -m http.server 4173`, opened `index.html` and captured a screenshot with Playwright to validate the indicator renders and is clickable, and the checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f28937bac8324978a0f1355adf8c3)