### PR TITLE
Improve readability and mobile compatibility for thomas-olive-branch page

### DIFF
--- a/thomas-olive-branch.html
+++ b/thomas-olive-branch.html
@@ -23,10 +23,10 @@
       --maxw: 1220px;
     }
     *{ box-sizing:border-box; }
-    html,body{ height:100%; margin:0; background:var(--bg); color:var(--text); font-family:var(--sans); overflow:hidden; }
+    html,body{ height:100%; margin:0; background:var(--bg); color:var(--text); font-family:var(--sans); line-height:1.5; }
     a{ color:inherit; }
     .app{
-      height:100%;
+      min-height:100dvh;
       display:grid;
       grid-template-rows:auto 1fr auto;
       background:
@@ -41,6 +41,8 @@
       border-bottom:1px solid var(--line);
       background: rgba(16,24,38,.72);
       backdrop-filter: blur(10px);
+      gap: 12px;
+      flex-wrap: wrap;
     }
     .title{ display:flex; flex-direction:column; gap:2px; min-width:0; }
     .title h1{ margin:0; font-size:14px; letter-spacing:.2px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
@@ -54,6 +56,7 @@
       border-radius: 999px;
       padding: 8px 12px;
       font-size: 12px;
+      min-height: 40px;
       cursor: pointer;
       user-select: none;
       transition: transform .06s ease, border-color .12s ease, background .12s ease;
@@ -70,20 +73,70 @@
     main{
       padding: 18px;
       display:flex; justify-content:center; align-items:stretch;
-      overflow:hidden;
+      overflow: hidden;
     }
     .frame{
-      width:min(var(--maxw), calc(100vw - 36px));
-      height: calc(100vh - 140px);
+      width:min(var(--maxw), 100%);
+      height: calc(100dvh - 140px);
       display:grid;
       grid-template-columns: 1.1fr .9fr;
       gap: 14px;
     }
     @media (max-width: 980px){
-      body{ overflow:auto; }
+      main{ padding: 12px; }
       .frame{
         height:auto;
         grid-template-columns:1fr;
+        gap: 12px;
+      }
+      .panel{
+        min-height: unset;
+      }
+      footer{
+        padding: 10px 12px 14px;
+      }
+      .progress{
+        width: 100%;
+      }
+    }
+
+    @media (max-width: 680px){
+      header{
+        padding: 12px;
+      }
+      .title h1{
+        font-size: 13px;
+        white-space: normal;
+      }
+      .title .subtitle{
+        white-space: normal;
+      }
+      .controls{
+        width: 100%;
+        justify-content: flex-start;
+        flex-wrap: wrap;
+      }
+      .pill{
+        width: 100%;
+        justify-content: center;
+      }
+      .scene-title{
+        font-size: clamp(20px, 7vw, 24px);
+      }
+      .narrative{
+        font-size: 15px;
+        line-height: 1.7;
+      }
+      .choice{
+        font-size: 14px;
+        padding: 12px;
+      }
+      .panel header h2{
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      svg{
+        height: 300px;
       }
     }
 
@@ -140,7 +193,7 @@
 
     .narrative{
       color: rgba(233,238,246,.92);
-      font-size: 16px;
+      font-size: clamp(15px, 1.25vw, 17px);
       line-height: 1.6;
       margin-bottom: 14px;
       white-space: pre-wrap;
@@ -268,7 +321,7 @@
 
     footer{
       display:flex; justify-content:space-between; align-items:center;
-      padding: 10px 18px 14px;
+      padding: 10px 18px calc(14px + env(safe-area-inset-bottom));
       border-top: 1px solid var(--line);
       background: rgba(16,24,38,.62);
       backdrop-filter: blur(10px);
@@ -290,6 +343,7 @@
     }
     .progress{
       width: 260px;
+      max-width: 100%;
       height: 8px;
       background: rgba(233,238,246,.08);
       border-radius: 999px;
@@ -301,6 +355,12 @@
       width: 0%;
       background: linear-gradient(90deg, rgba(124,212,255,.95), rgba(181,255,124,.85));
       transition: width .18s ease;
+    }
+
+    @media (prefers-reduced-motion: reduce){
+      *, *::before, *::after{
+        transition: none !important;
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
### Motivation
- Improve text legibility and touch usability across devices by adjusting baseline typography and control sizing. 
- Make the two-panel layout and map behave more reliably on modern mobile viewports where the visual viewport can change (addressing scroll/viewport quirks). 
- Add small responsive tweaks and accessibility improvements for narrow screens and motion-sensitive users.

### Description
- Adjusted global typography by adding `line-height: 1.5` and made the narrative text responsive with `font-size: clamp(15px, 1.25vw, 17px)`. 
- Stabilized mobile sizing by switching the app container to `min-height: 100dvh` and using `height: calc(100dvh - 140px)` for the main frame. 
- Added responsive breakpoints `@media (max-width: 980px)` and `@media (max-width: 680px)` to stack panels, tighten paddings, unwrap header text, wrap controls, and scale `svg`, `.scene-title`, `.narrative`, and `.choice` typography for small screens. 
- Improved touch targets by setting `min-height: 40px` on `button`/`.pill`, made the progress bar flexible (`max-width: 100%`), and added safe-area-aware footer padding via `env(safe-area-inset-bottom)`. 
- Added `@media (prefers-reduced-motion: reduce)` to disable transitions for users who prefer reduced motion.

### Testing
- Ran `git diff --check` with no issues. 
- Served the page locally with `python3 -m http.server 4173 --bind 0.0.0.0` and validated rendering. 
- Captured a mobile validation screenshot using Playwright with `page.goto('http://127.0.0.1:4173/thomas-olive-branch.html', wait_until='networkidle')` and saving `artifacts/thomas-olive-branch-mobile.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69979798a9fc83249aed4950113b5f5f)