### PR TITLE
Rewrite posts/money.html into interactive layered Money Flow Atlas

### DIFF
--- a/posts/money.html
+++ b/posts/money.html
@@ -3,251 +3,376 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>Money Flow Engine — Layered</title>
+<title>Money Flow Engine — Interactive Atlas</title>
 
 <style>
 :root{
---bg:#070b12;
---panel:#111a2b;
---node:#1f2f45;
---accent:#7cd4ff;
---accent2:#9cffb5;
---warn:#ffb86b;
---danger:#ff6b6b;
---text:#f2f6ff;
---muted:#a9bbd6;
+  --bg:#070b12;
+  --panel:#111a2b;
+  --panel-soft:#15233a;
+  --node:#1f2f45;
+  --accent:#7cd4ff;
+  --accent2:#9cffb5;
+  --warn:#ffb86b;
+  --danger:#ff6b6b;
+  --text:#f2f6ff;
+  --muted:#a9bbd6;
 }
 
+*{box-sizing:border-box}
+
 body{
-margin:0;
-background:radial-gradient(circle at 50% 20%, #0d1828, #070b12 75%);
-color:var(--text);
-font-family:Inter,system-ui;
-display:flex;
-flex-direction:column;
-align-items:center;
+  margin:0;
+  background:radial-gradient(circle at 50% 20%, #0d1828, #070b12 75%);
+  color:var(--text);
+  font-family:Inter,system-ui,sans-serif;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  min-height:100vh;
 }
 
 header{
-padding:26px 20px 10px;
-text-align:center;
+  padding:26px 20px 10px;
+  text-align:center;
+}
+
+header p{
+  color:var(--muted);
+  margin:0;
 }
 
 #wrap{
-width:100%;
-max-width:1250px;
-padding:18px;
-display:grid;
-grid-template-columns:1fr 360px;
-gap:18px;
+  width:100%;
+  max-width:1320px;
+  padding:18px;
+  display:grid;
+  grid-template-columns:minmax(0,1fr) 390px;
+  gap:18px;
 }
 
 .card{
-background:linear-gradient(180deg,#121d30,#0f1828);
-border-radius:18px;
-padding:18px;
-box-shadow:0 20px 50px rgba(0,0,0,.6);
+  background:linear-gradient(180deg,#121d30,#0f1828);
+  border-radius:18px;
+  padding:18px;
+  box-shadow:0 20px 50px rgba(0,0,0,.55);
+}
+
+.controls{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin-bottom:10px;
 }
 
 .controls button{
-margin:4px;
-padding:6px 12px;
-border-radius:8px;
-border:1px solid #2a3f5a;
-background:#162236;
-color:var(--muted);
-cursor:pointer;
-font-size:13px;
+  padding:7px 12px;
+  border-radius:9px;
+  border:1px solid #2a3f5a;
+  background:#162236;
+  color:var(--muted);
+  cursor:pointer;
+  font-size:13px;
 }
 
-.controls button.active{
-border-color:var(--accent);
-color:var(--text);
+.controls button.active,
+.controls button:hover{
+  border-color:var(--accent);
+  color:var(--text);
 }
 
 svg{
-width:100%;
-height:640px;
+  width:100%;
+  height:640px;
 }
 
 .node circle{
-fill:var(--node);
-stroke:var(--accent);
-stroke-width:2;
-transition:.25s;
+  fill:var(--node);
+  stroke:var(--accent);
+  stroke-width:2;
+  transition:.25s;
+  cursor:pointer;
 }
 
 .node text{
-fill:#ffffff;
-font-size:16px;
-font-weight:500;
-letter-spacing:.3px;
-pointer-events:none;
+  fill:#fff;
+  font-size:16px;
+  font-weight:600;
+  letter-spacing:.3px;
+  pointer-events:none;
+}
+
+.node:hover circle,
+.node.selected circle{
+  stroke-width:3;
+  filter:drop-shadow(0 0 10px rgba(124,212,255,.65));
 }
 
 .node.owned circle{
-stroke:var(--warn);
-filter:drop-shadow(0 0 14px rgba(255,184,107,.6));
+  stroke:var(--warn);
+  filter:drop-shadow(0 0 14px rgba(255,184,107,.55));
 }
 
 .flow{
-fill:none;
-stroke:var(--accent2);
-stroke-width:3;
-stroke-dasharray:10 8;
-opacity:.75;
-marker-end:url(#arrow);
+  fill:none;
+  stroke:var(--accent2);
+  stroke-width:3;
+  stroke-dasharray:10 8;
+  opacity:.7;
+  marker-end:url(#arrow);
+  cursor:pointer;
+  transition:.2s;
+}
+
+.flow:hover,
+.flow.active{
+  opacity:1;
+  stroke-width:4;
+}
+
+.policy,
+.missing{
+  fill:none;
+  opacity:0;
+  transition:.35s;
 }
 
 .policy{
-stroke:var(--warn);
-stroke-width:2.5;
-stroke-dasharray:4 6;
-opacity:0;
-transition:.4s;
-}
-
-.policy.visible{
-opacity:.95;
+  stroke:var(--warn);
+  stroke-width:2.5;
+  stroke-dasharray:4 6;
 }
 
 .missing{
-stroke:var(--danger);
-stroke-width:4;
-stroke-dasharray:4 6;
-opacity:0;
+  stroke:var(--danger);
+  stroke-width:4;
+  stroke-dasharray:4 6;
 }
 
+.policy.visible{opacity:.95}
 .missing.visible{
-opacity:1;
-filter:drop-shadow(0 0 12px rgba(255,107,107,.7));
+  opacity:1;
+  filter:drop-shadow(0 0 12px rgba(255,107,107,.7));
 }
 
+.side h2,
 .side h3{
-margin-top:0;
-font-weight:600;
+  margin-top:0;
 }
 
-.side p{
-line-height:1.5;
-color:var(--muted);
+.meta{
+  margin:8px 0 16px;
+  color:var(--muted);
+  line-height:1.45;
+}
+
+#detail{
+  background:var(--panel-soft);
+  border:1px solid #26405d;
+  border-radius:12px;
+  padding:14px;
+  min-height:130px;
+  line-height:1.5;
+  color:var(--muted);
+}
+
+.log{
+  margin-top:14px;
+  max-height:260px;
+  overflow:auto;
+  font-family:ui-monospace,monospace;
+  font-size:12px;
+}
+
+.entry{
+  margin-bottom:12px;
+  border-left:2px solid #33527a;
+  padding-left:10px;
+}
+
+.tag{color:var(--accent)}
+
+@media (max-width:1000px){
+  #wrap{grid-template-columns:1fr}
+  svg{height:560px}
 }
 </style>
 </head>
 
 <body>
-
 <header>
-<h1>Money Flow Engine</h1>
-<div style="color:var(--muted)">Layered ownership • policy • structural forks</div>
+  <h1>Money Flow Engine</h1>
+  <p>Layered ownership • policy leverage • interactive circulation map</p>
 </header>
 
 <div id="wrap">
+  <div class="card">
+    <div class="controls">
+      <button data-layer="base" class="active">Base circulation</button>
+      <button data-layer="ownership">Ownership</button>
+      <button data-layer="policy">Policy pressure</button>
+      <button data-layer="missing">Missing links</button>
+    </div>
 
-<div class="card">
+    <svg viewBox="0 0 900 640" id="moneyFlow">
+      <defs>
+        <marker id="arrow" markerWidth="8" markerHeight="8" refX="5" refY="3" orient="auto">
+          <path d="M0,0 L6,3 L0,6 Z" fill="#9cffb5"/>
+        </marker>
+      </defs>
 
-<div class="controls">
-<button data-layer="base" class="active">Base</button>
-<button data-layer="ownership">Ownership</button>
-<button data-layer="policy">Policy</button>
-<button data-layer="missing">Missing links</button>
-</div>
+      <g class="node" id="Infrastructure" data-node="Infrastructure" transform="translate(450,110)">
+        <circle r="90"/>
+        <text text-anchor="middle" dy="6">Infrastructure</text>
+      </g>
 
-<svg viewBox="0 0 900 640">
+      <g class="node" id="Firms" data-node="Firms" transform="translate(760,330)">
+        <circle r="90"/>
+        <text text-anchor="middle" dy="6">Firms</text>
+      </g>
 
-<defs>
-<marker id="arrow" markerWidth="8" markerHeight="8" refX="5" refY="3" orient="auto">
-<path d="M0,0 L6,3 L0,6 Z" fill="#9cffb5"/>
-</marker>
-</defs>
+      <g class="node" id="Finance" data-node="Finance" transform="translate(450,330)">
+        <circle r="75"/>
+        <text text-anchor="middle" dy="6">Finance</text>
+      </g>
 
-<g class="node" id="Infrastructure" transform="translate(450,110)">
-<circle r="90"/>
-<text text-anchor="middle" dy="6">Infrastructure</text>
-</g>
+      <g class="node" id="Government" data-node="Government" transform="translate(140,330)">
+        <circle r="90"/>
+        <text text-anchor="middle" dy="6">Government</text>
+      </g>
 
-<g class="node owned" id="Firms" transform="translate(760,330)">
-<circle r="90"/>
-<text text-anchor="middle" dy="6">Firms</text>
-</g>
+      <g class="node" id="Households" data-node="Households" transform="translate(450,560)">
+        <circle r="90"/>
+        <text text-anchor="middle" dy="6">Households</text>
+      </g>
 
-<g class="node owned" id="Finance" transform="translate(450,330)">
-<circle r="75"/>
-<text text-anchor="middle" dy="6">Finance</text>
-</g>
+      <path class="flow" data-flow="Consumption" d="M520 540 Q720 480 760 370"/>
+      <path class="flow" data-flow="Wages" d="M700 330 Q560 480 500 540"/>
+      <path class="flow" data-flow="Investment" d="M720 260 Q560 160 470 150"/>
+      <path class="flow" data-flow="Taxes" d="M390 540 Q210 410 160 370"/>
+      <path class="flow" data-flow="Transfers" d="M160 290 Q300 470 420 540"/>
+      <path class="flow" data-flow="Credit" d="M450 330 Q620 330 740 330"/>
+      <path class="flow" data-flow="Interest" d="M450 330 Q260 330 160 330"/>
 
-<g class="node" id="Government" transform="translate(140,330)">
-<circle r="90"/>
-<text text-anchor="middle" dy="6">Government</text>
-</g>
+      <path id="policyInfra" class="policy" d="M140 330 Q300 200 450 150"/>
+      <path id="policyHouseholds" class="policy" d="M140 330 Q280 500 430 550"/>
 
-<g class="node" id="Households" transform="translate(450,560)">
-<circle r="90"/>
-<text text-anchor="middle" dy="6">Households</text>
-</g>
+      <path id="missingInfra" class="missing" d="M140 330 Q300 200 450 150"/>
+      <path id="missingFinanceInfra" class="missing" d="M450 330 Q455 200 455 150"/>
+    </svg>
+  </div>
 
-<!-- base flows -->
-<path class="flow" d="M520 540 Q720 480 760 370"/>
-<path class="flow" d="M700 330 Q560 480 500 540"/>
-<path class="flow" d="M720 260 Q560 160 470 150"/>
-<path class="flow" d="M390 540 Q210 410 160 370"/>
-<path class="flow" d="M160 290 Q300 470 420 540"/>
-<path class="flow" d="M450 330 Q620 330 740 330"/>
-<path class="flow" d="M450 330 Q260 330 160 330"/>
+  <div class="card side">
+    <h2 id="layerTitle">Layer: Base circulation</h2>
+    <p id="layerDesc" class="meta">Click any node or flow to inspect its role in the system.</p>
+    <h3 id="focusTitle">Select a node or flow</h3>
+    <div id="detail">The map combines topology, ownership overlays, policy vectors, and diagnostic missing links.</div>
 
-<!-- policy -->
-<path id="policyInfra" class="policy" d="M140 330 Q300 200 450 150"/>
-
-<!-- missing -->
-<path id="missingInfra" class="missing" d="M140 330 Q300 200 450 150"/>
-
-</svg>
-
-</div>
-
-<div class="card side">
-<h3 id="title">Layer: Base</h3>
-<p id="desc">
-Base layer shows circulation.  
-Other layers reveal ownership, policy leverage, and structural gaps.
-</p>
-</div>
-
+    <div class="log" id="log"></div>
+  </div>
 </div>
 
 <script>
+const layerContent={
+  base:{
+    title:"Layer: Base circulation",
+    desc:"Tracks movement of wages, spending, taxes, transfers, investment, and credit."
+  },
+  ownership:{
+    title:"Layer: Ownership",
+    desc:"Highlights where asset ownership concentrates cashflow and long-run control."
+  },
+  policy:{
+    title:"Layer: Policy pressure",
+    desc:"Shows direct levers public institutions can pull into infrastructure and households."
+  },
+  missing:{
+    title:"Layer: Missing links",
+    desc:"Flags fragile or under-built channels where the system often stalls in practice."
+  }
+};
+
+const nodeInfo={
+  Infrastructure:"Physical substrate: energy, roads, housing, and networks that set the economy's speed limit.",
+  Firms:"Production and pricing engine. Converts labor + capital into goods, services, and retained earnings.",
+  Finance:"Allocation layer. Chooses what gets funded, what gets delayed, and how risk is distributed.",
+  Government:"Rule author, stabilizer, and insurer. Collects taxes and redirects spending to shape outcomes.",
+  Households:"Labor supply and demand base. Income arrives mainly as wages and exits as consumption and taxes."
+};
+
+const flowInfo={
+  Consumption:"Households → Firms: spending converts earned income into business revenue.",
+  Wages:"Firms → Households: labor compensation that seeds the next consumption cycle.",
+  Investment:"Firms → Infrastructure: long-lived capital commitments that increase future output.",
+  Taxes:"Households/Firms → Government: public revenue extraction for collective provisioning.",
+  Transfers:"Government → Households: stabilization and redistribution channel.",
+  Credit:"Finance → Firms/Households: creates purchasing power ahead of current income.",
+  Interest:"Economy → Finance: return stream that rewards lenders and reprices risk over time."
+};
+
 const buttons=document.querySelectorAll(".controls button");
-const policy=document.getElementById("policyInfra");
-const missing=document.getElementById("missingInfra");
 const nodes=document.querySelectorAll(".node");
+const flows=document.querySelectorAll(".flow");
+const policyLines=[document.getElementById("policyInfra"),document.getElementById("policyHouseholds")];
+const missingLines=[document.getElementById("missingInfra"),document.getElementById("missingFinanceInfra")];
+const log=document.getElementById("log");
+
+function addEntry(kind,name,text){
+  const entry=document.createElement("div");
+  entry.className="entry";
+  entry.innerHTML=`<div class="tag">[${kind}] ${name}</div><div>${text}</div>`;
+  log.prepend(entry);
+}
+
+function setLayer(layer){
+  buttons.forEach(b=>b.classList.toggle("active",b.dataset.layer===layer));
+  nodes.forEach(n=>n.classList.remove("owned"));
+  policyLines.forEach(line=>line.classList.remove("visible"));
+  missingLines.forEach(line=>line.classList.remove("visible"));
+
+  if(layer==="ownership"){
+    document.getElementById("Firms").classList.add("owned");
+    document.getElementById("Finance").classList.add("owned");
+  }
+  if(layer==="policy"){
+    policyLines.forEach(line=>line.classList.add("visible"));
+  }
+  if(layer==="missing"){
+    missingLines.forEach(line=>line.classList.add("visible"));
+  }
+
+  document.getElementById("layerTitle").textContent=layerContent[layer].title;
+  document.getElementById("layerDesc").textContent=layerContent[layer].desc;
+  addEntry("LAYER",layerContent[layer].title,layerContent[layer].desc);
+}
 
 buttons.forEach(b=>{
-b.onclick=()=>{
-buttons.forEach(x=>x.classList.remove("active"));
-b.classList.add("active");
-
-const layer=b.dataset.layer;
-
-policy.classList.remove("visible");
-missing.classList.remove("visible");
-nodes.forEach(n=>n.classList.remove("owned"));
-
-if(layer==="ownership"){
-document.getElementById("Firms").classList.add("owned");
-document.getElementById("Finance").classList.add("owned");
-}
-
-if(layer==="policy"){
-policy.classList.add("visible");
-}
-
-if(layer==="missing"){
-missing.classList.add("visible");
-}
-
-document.getElementById("title").textContent="Layer: "+layer;
-};
+  b.addEventListener("click",()=>setLayer(b.dataset.layer));
 });
+
+nodes.forEach(node=>{
+  node.addEventListener("click",()=>{
+    const name=node.dataset.node;
+    nodes.forEach(n=>n.classList.remove("selected"));
+    node.classList.add("selected");
+    document.getElementById("focusTitle").textContent=name;
+    document.getElementById("detail").textContent=nodeInfo[name];
+    addEntry("NODE",name,nodeInfo[name]);
+  });
+});
+
+flows.forEach(flow=>{
+  flow.addEventListener("click",()=>{
+    const name=flow.dataset.flow;
+    flows.forEach(f=>f.classList.remove("active"));
+    flow.classList.add("active");
+    document.getElementById("focusTitle").textContent=name;
+    document.getElementById("detail").textContent=flowInfo[name];
+    addEntry("FLOW",name,flowInfo[name]);
+  });
+});
+
+addEntry("SYSTEM","Money Flow Engine initialized","Base topology loaded. Select any layer, node, or flow.");
 </script>
 
 </body>


### PR DESCRIPTION
### Motivation
- Combine the best elements from several draft variants into a single, clearer, and more interactive exposition of the money‑flow model with layered diagnostics.
- Provide an explorable visual that surfaces ownership, policy levers, and structural gaps in addition to base circulation.

### Description
- Rewrote `posts/money.html` as a single self‑contained interactive page that consolidates topology, layer controls, overlays, and improved styling into an "Interactive Atlas" view.
- Added UI layer controls (`base`, `ownership`, `policy`, `missing`) that toggle visual overlays and ownership highlights, plus extra policy/missing overlay paths for diagnostics.
- Implemented direct click interactions for nodes and flows so the right panel updates with focused copy and the action is recorded in a rolling observation log.
- Improved CSS for consistent theming, hover/selected states, responsiveness, and a compact side detail card with a dynamic title/description area.

### Testing
- Launched a local static server and requested the page headers via `curl`, which returned `200 OK`, confirming the file serves correctly (success).
- Captured a headless browser screenshot of `posts/money.html` using Playwright to validate rendering; the screenshot artifact was produced (success).
- Verified interactive initialization by confirming the observation log is seeded with the system initialization entry after load (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998bca9f3948324a74e7dd03495cdc7)