### PR TITLE
Extend missing-link chain to households in money flow visualization

### DIFF
--- a/posts/money.html
+++ b/posts/money.html
@@ -257,8 +257,10 @@ svg{
       <path id="policyInfra" class="policy" d="M140 330 Q300 200 450 150"/>
       <path id="policyHouseholds" class="policy" d="M140 330 Q280 500 430 550"/>
 
-      <path id="missingInfra" class="missing" d="M140 330 Q300 200 450 150"/>
-      <path id="missingFinanceInfra" class="missing" d="M450 330 Q455 200 455 150"/>
+      <path id="missingGovInfra" class="missing" d="M140 330 Q300 200 450 150"/>
+      <path id="missingInfraFinance" class="missing" d="M455 150 Q455 240 450 330"/>
+      <path id="missingFinanceHouseholds" class="missing" d="M450 330 Q450 440 450 560"/>
+      <path id="missingBenefitsToFirms" class="missing" d="M140 330 Q420 240 740 330"/>
     </svg>
   </div>
 
@@ -288,7 +290,7 @@ const layerContent={
   },
   missing:{
     title:"Layer: Missing links",
-    desc:"Flags fragile or under-built channels where the system often stalls in practice."
+    desc:"Traces the broken chain Government → Infrastructure → Finance → Households, while showing how health and retirement outlays are often captured by firms before households can build assets."
   }
 };
 
@@ -314,7 +316,12 @@ const buttons=document.querySelectorAll(".controls button");
 const nodes=document.querySelectorAll(".node");
 const flows=document.querySelectorAll(".flow");
 const policyLines=[document.getElementById("policyInfra"),document.getElementById("policyHouseholds")];
-const missingLines=[document.getElementById("missingInfra"),document.getElementById("missingFinanceInfra")];
+const missingLines=[
+  document.getElementById("missingGovInfra"),
+  document.getElementById("missingInfraFinance"),
+  document.getElementById("missingFinanceHouseholds"),
+  document.getElementById("missingBenefitsToFirms")
+];
 const log=document.getElementById("log");
 
 function addEntry(kind,name,text){


### PR DESCRIPTION
### Motivation
- The money flow map previously stopped the "missing link" visualization early and needed to trace the downstream chain through infrastructure and finance to households. 
- The update also intends to highlight how public health and retirement spending can be captured by firms before households actually build assets.

### Description
- Added four new SVG missing-link paths in `posts/money.html`: `missingGovInfra`, `missingInfraFinance`, `missingFinanceHouseholds`, and `missingBenefitsToFirms` to represent Government → Infrastructure → Finance → Households and benefits leakage to firms. 
- Replaced the earlier two-segment missing overlay with the full chain and added the Government→Firms capture path to the SVG. 
- Updated the `missing` layer description in the `layerContent` object to reflect the new narrative. 
- Wired the new path IDs into the `missingLines` array so the existing layer toggle logic shows/hides the new lines together with the other overlays.

### Testing
- Started a local server with `python3 -m http.server 8000` to serve the updated page, which succeeded. 
- Ran a quick code check with `git diff --check`, which reported no whitespace/diff issues. 
- Attempted an automated screenshot using Playwright Chromium to validate the visual result, but the Chromium process crashed with a SIGSEGV in this environment (screenshot attempt failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998bed8ea408324834fdf5b634e20eb)