### PR TITLE
Merge capacity-routing simulator into `posts/money.html`

### DIFF
--- a/posts/money.html
+++ b/posts/money.html
@@ -42,13 +42,23 @@ header p{
   margin:0;
 }
 
-#wrap{
+#wrap,
+#capacityWrap{
   width:100%;
   max-width:1320px;
   padding:18px;
   display:grid;
-  grid-template-columns:minmax(0,1fr) 390px;
   gap:18px;
+}
+
+#wrap{
+  grid-template-columns:minmax(0,1fr) 390px;
+}
+
+#capacityWrap{
+  padding-top:0;
+  padding-bottom:30px;
+  grid-template-columns:minmax(0,1fr) minmax(0,1fr) 390px;
 }
 
 .card{
@@ -192,8 +202,56 @@ svg{
 
 .tag{color:var(--accent)}
 
+.cap-label{
+  font-size:13px;
+  color:var(--muted);
+}
+
+#direct{
+  width:100%;
+  margin:8px 0;
+}
+
+.bar{
+  height:28px;
+  border-radius:8px;
+  background:#1b2740;
+  margin:10px 0;
+  overflow:hidden;
+}
+
+.fill{
+  height:100%;
+  display:flex;
+  align-items:center;
+  padding-left:10px;
+  font-size:13px;
+  color:#09111f;
+  font-weight:600;
+}
+
+.phys{background:linear-gradient(90deg,#6cf,#9df);}
+.health{background:linear-gradient(90deg,#1f7,#3bd);}
+.edu{background:linear-gradient(90deg,#ffd38f,#ffe7b8);}
+.social{background:linear-gradient(90deg,#ffb86b,#ffd0a6);}
+.drag{background:linear-gradient(90deg,#ff6b6b,#ff9b9b);}
+
+.big{
+  font-size:18px;
+  margin-top:12px;
+}
+
+.math-log{
+  font-family:ui-monospace,monospace;
+  font-size:13px;
+  white-space:pre-wrap;
+  line-height:1.5;
+  color:var(--muted);
+}
+
 @media (max-width:1000px){
-  #wrap{grid-template-columns:1fr}
+  #wrap,
+  #capacityWrap{grid-template-columns:1fr}
   svg{height:560px}
 }
 </style>
@@ -271,6 +329,36 @@ svg{
     <div id="detail">The map combines topology, ownership overlays, policy vectors, and diagnostic missing links.</div>
 
     <div class="log" id="log"></div>
+  </div>
+</div>
+
+<div id="capacityWrap">
+  <div class="card">
+    <h2>Foundational Systems Capacity</h2>
+    <p class="meta">A companion model: route more of the same spending directly into productive capacity to lower drag and increase output.</p>
+
+    <label class="cap-label" for="direct">Direct capacity routing (<span id="directPct">55%</span>)</label>
+    <input type="range" id="direct" min="20" max="90" value="55" aria-label="Direct capacity routing percentage">
+
+    <div class="bar"><div id="phys" class="fill phys"></div></div>
+    <div class="bar"><div id="healthCap" class="fill health"></div></div>
+    <div class="bar"><div id="edu" class="fill edu"></div></div>
+    <div class="bar"><div id="socialCap" class="fill social"></div></div>
+    <div class="bar"><div id="drag" class="fill drag"></div></div>
+  </div>
+
+  <div class="card">
+    <h2>Totals</h2>
+
+    <div class="big" id="pool"></div>
+    <div class="big" id="directAmt"></div>
+    <div class="big" id="indirectAmt"></div>
+    <div class="big" id="capacityTotal"></div>
+  </div>
+
+  <div class="card">
+    <h3>Live math</h3>
+    <div id="mathLog" class="math-log"></div>
   </div>
 </div>
 
@@ -380,6 +468,67 @@ flows.forEach(flow=>{
 });
 
 addEntry("SYSTEM","Money Flow Engine initialized","Base topology loaded. Select any layer, node, or flow.");
+
+const pool=8.5; // trillions
+const slider=document.getElementById("direct");
+
+function updateCapacity(){
+  const d=slider.value/100;
+
+  const directAmt=pool*d;
+  const indirect=pool-directAmt;
+  const systemDrag=indirect*0.25;
+
+  const phys=directAmt*0.2;
+  const health=directAmt*0.35;
+  const edu=directAmt*0.18;
+  const social=directAmt*0.27;
+
+  const capacityTotal=directAmt+(indirect-systemDrag);
+
+  setBar("phys","Physical infrastructure",phys);
+  setBar("healthCap","Health capacity",health);
+  setBar("edu","Education capacity",edu);
+  setBar("socialCap","Stabilization capacity",social);
+  setBar("drag","System drag",systemDrag);
+
+  document.getElementById("directPct").innerText=`${slider.value}%`;
+  document.getElementById("pool").innerText=`Total pool: $${pool.toFixed(2)}T`;
+  document.getElementById("directAmt").innerText=`Direct capacity: $${directAmt.toFixed(2)}T`;
+  document.getElementById("indirectAmt").innerText=`Indirect routed: $${indirect.toFixed(2)}T`;
+  document.getElementById("capacityTotal").innerText=`Total capacity produced: $${capacityTotal.toFixed(2)}T`;
+
+  renderMath(d,directAmt,indirect,systemDrag,capacityTotal);
+}
+
+function setBar(id,label,val){
+  const el=document.getElementById(id);
+  el.style.width=`${Math.max(12,val*18)}%`;
+  el.innerText=`${label} ≈ $${val.toFixed(2)}T`;
+}
+
+function renderMath(d,direct,indirect,drag,cap){
+  document.getElementById("mathLog").innerText=
+`Pool = ${pool.toFixed(2)}T
+
+Direct routing = Pool × ${d.toFixed(2)}
+→ ${direct.toFixed(2)}T
+
+Indirect routing = ${indirect.toFixed(2)}T
+
+Drag (25% of indirect) = ${drag.toFixed(2)}T
+
+Capacity produced =
+Direct + (Indirect − Drag)
+= ${cap.toFixed(2)}T
+
+Interpretation:
+Total spending stays constant.
+Routing changes output.`;
+}
+
+slider.addEventListener("input",updateCapacity);
+updateCapacity();
 </script>
 
 </body>


### PR DESCRIPTION
### Motivation
- Add an interactive, compact capacity-routing model beneath the existing Money Flow Engine map to demonstrate how routing spending directly into productive systems changes total produced capacity.
- Keep the extension visually and behaviorally consistent with the existing page so the new model reads as an integrated companion, not a separate page.
- Provide a lightweight live-math view so readers can experiment with routing and see immediate numeric and visual feedback.

### Description
- Merged the supplied capacity HTML/JS into `posts/money.html` under a new `#capacityWrap` section that contains three cards: `Foundational Systems Capacity`, `Totals`, and `Live math` and added responsive grid layout support for the new section.
- Added scoped CSS for the capacity UI (labels, slider, `.bar`/.`fill` styles and color tokens) and adjusted the top-level grid rules so `#wrap` and `#capacityWrap` coexist responsively.
- Implemented interactive logic with a slider (`#direct`) and functions `updateCapacity`, `setBar`, and `renderMath` that compute `directAmt`, `indirect`, `systemDrag`, per-category allocations (`phys`, `health`, `edu`, `social`), and the `capacityTotal` using a `pool` constant (`8.5` trillions), and update the DOM accordingly.
- Small refinements: clearer explanatory copy, an accessible `aria-label` on the slider, formatted percentage display (`#directPct`), and a monospace live math panel for readable equations.

### Testing
- HTML parsing with Python's `html.parser` succeeded when feeding `posts/money.html` to ensure the document is syntactically consumable by standard parsers.
- Served the site with `python3 -m http.server` and captured a full-page screenshot via an automated Playwright script against `http://127.0.0.1:4173/posts/money.html`, confirming the new UI renders and the slider-driven sections appear.
- Attempted `xmllint --html --noout posts/money.html` but the tool was unavailable in the environment; this check was skipped due to the missing binary.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c93897d0832483a70b75cceead41)