### PR TITLE
Improve readability styling for posts/money.html

### DIFF
--- a/posts/money.html
+++ b/posts/money.html
@@ -26,6 +26,8 @@ body{
   background:radial-gradient(circle at 50% 20%, #0d1828, #070b12 75%);
   color:var(--text);
   font-family:Inter,system-ui,sans-serif;
+  line-height:1.6;
+  letter-spacing:.01em;
   display:flex;
   flex-direction:column;
   align-items:center;
@@ -64,8 +66,13 @@ header p{
 .card{
   background:linear-gradient(180deg,#121d30,#0f1828);
   border-radius:18px;
-  padding:18px;
+  padding:22px;
   box-shadow:0 20px 50px rgba(0,0,0,.55);
+}
+
+h1,h2,h3{
+  line-height:1.2;
+  margin-bottom:10px;
 }
 
 .controls{
@@ -172,8 +179,9 @@ svg{
 
 .meta{
   margin:8px 0 16px;
-  color:var(--muted);
-  line-height:1.45;
+  color:#c1d0e8;
+  font-size:1.05rem;
+  line-height:1.6;
 }
 
 #detail{
@@ -182,8 +190,9 @@ svg{
   border-radius:12px;
   padding:14px;
   min-height:130px;
-  line-height:1.5;
-  color:var(--muted);
+  line-height:1.65;
+  color:#d7e3f6;
+  font-size:1.02rem;
 }
 
 .log{
@@ -191,7 +200,8 @@ svg{
   max-height:260px;
   overflow:auto;
   font-family:ui-monospace,monospace;
-  font-size:12px;
+  font-size:13px;
+  line-height:1.45;
 }
 
 .entry{
@@ -203,8 +213,8 @@ svg{
 .tag{color:var(--accent)}
 
 .cap-label{
-  font-size:13px;
-  color:var(--muted);
+  font-size:16px;
+  color:#c8d6ec;
 }
 
 #direct{
@@ -213,10 +223,10 @@ svg{
 }
 
 .bar{
-  height:28px;
+  min-height:40px;
   border-radius:8px;
   background:#1b2740;
-  margin:10px 0;
+  margin:12px 0;
   overflow:hidden;
 }
 
@@ -225,9 +235,11 @@ svg{
   display:flex;
   align-items:center;
   padding-left:10px;
-  font-size:13px;
+  font-size:18px;
   color:#09111f;
-  font-weight:600;
+  font-weight:700;
+  white-space:normal;
+  line-height:1.2;
 }
 
 .phys{background:linear-gradient(90deg,#6cf,#9df);}
@@ -237,22 +249,30 @@ svg{
 .drag{background:linear-gradient(90deg,#ff6b6b,#ff9b9b);}
 
 .big{
-  font-size:18px;
+  font-size:24px;
+  line-height:1.4;
   margin-top:12px;
 }
 
 .math-log{
   font-family:ui-monospace,monospace;
-  font-size:13px;
+  font-size:19px;
   white-space:pre-wrap;
-  line-height:1.5;
-  color:var(--muted);
+  line-height:1.65;
+  color:#d3e0f4;
+}
+
+@media (max-width:1200px){
+  .big{font-size:22px}
+  .math-log{font-size:17px}
 }
 
 @media (max-width:1000px){
   #wrap,
   #capacityWrap{grid-template-columns:1fr}
   svg{height:560px}
+  .big{font-size:20px}
+  .math-log{font-size:15px}
 }
 </style>
 </head>


### PR DESCRIPTION
### Motivation
- Make the `posts/money.html` interactive visualization easier to read and scan by improving typography, spacing, and contrast across the page.
- Improve legibility of the capacity and totals panels so numeric labels and the live math are clearer at multiple viewport sizes.

### Description
- Increased base typography rhythm by adding `line-height` and `letter-spacing` to `body` and added consistent heading spacing via `h1,h2,h3` rules.
- Increased card padding and boosted supporting text contrast and size by updating `.meta`, `#detail`, and `.log` styles for clearer descriptive text and logs.
- Improved capacity panel readability by enlarging `.cap-label`, increasing `.bar` height to `min-height:40px`, and increasing `.fill` font size/weight with `white-space:normal`.
- Enlarged totals and live-math text (`.big`, `.math-log`) with responsive scaling rules for narrower viewports to keep values legible on smaller screens.

### Testing
- Parsed the updated HTML with Python's `html.parser` to ensure no syntax errors, and the parser completed successfully.
- Served the site locally with `python3 -m http.server` and captured a screenshot of `posts/money.html` via an automated Playwright script to validate visual changes, which succeeded and produced an artifact.
- Attempted `xmllint --html --noout posts/money.html` but the `xmllint` tool was not available in the environment, so that specific check was skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ca90c2a08324a7bc1cc4c1e0143a)