### PR TITLE
Open compiled PDF from draft.tex when printing thesis page

### DIFF
--- a/posts/thesis.html
+++ b/posts/thesis.html
@@ -215,7 +215,7 @@ code{
   <div class="controls">
     <button id="expand">Expand all</button>
     <button id="collapse">Collapse all</button>
-    <button onclick="window.print()">Print / PDF</button>
+    <button id="print-pdf">Print Thesis PDF</button>
   </div>
 </header>
 
@@ -384,6 +384,12 @@ sections.forEach(s=>{
 
 document.getElementById("expand").onclick = expandAll;
 document.getElementById("collapse").onclick = collapseAll;
+
+document.getElementById("print-pdf").addEventListener("click", ()=>{
+  const sourceTexUrl = "https://raw.githubusercontent.com/davidlones/public/main/thesis/draft.tex";
+  const compiledPdfUrl = `https://latexonline.cc/compile?url=${encodeURIComponent(sourceTexUrl)}`;
+  window.open(compiledPdfUrl, "_blank", "noopener");
+});
 
 // Start collapsed for windowed contexts
 collapseAll();


### PR DESCRIPTION
### Motivation
- The HTML `Print / PDF` control printed the webpage via `window.print()`, which can produce different output than the canonical LaTeX source. 
- The page should print the authoritative PDF generated from the repository TeX source at `https://github.com/davidlones/public/blob/main/thesis/draft.tex` for consistent, typeset output.

### Description
- Replaced the `Print / PDF` button in `posts/thesis.html` with a `Print Thesis PDF` button having id `print-pdf`.
- Added a click handler that points to the raw TeX source and opens a compiled PDF via `https://latexonline.cc/compile?url=...` in a new tab.
- Left existing expand/collapse behavior and page structure unchanged.

### Testing
- Launched a local server with `python -m http.server 8000` and served `posts/thesis.html`, which started successfully.
- Ran a Playwright script that loaded `http://127.0.0.1:8000/posts/thesis.html` and captured a screenshot to verify the updated UI, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b6ec255c8832486feef83289ab586)